### PR TITLE
renamed aeroConfig to pushConfig, add alias in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ Note that after installing the plugin on an iOS Cordova project, you need to ins
 The below JavaScript code registers a device in the AeroGear Unified Push Server devices registry:
 
 ```js
-var aeroConfig = {
+var pushConfig = {
     // senderID is only used in the Android/GCM case
     senderID: "<senderID>",
     pushServerURL: "<pushServerURL>",
     variantID: "<variantID>",
-    variantSecret: "<variantSecret>"
+    variantSecret: "<variantSecret>",
+    alias: "<alias>"
 }
 
 push.register(successHandler, errorHandler, {"badge": "true", "sound": "true",
-    "alert": "true", "ecb": "onNotification", aeroConfig: aeroConfig});
+    "alert": "true", "ecb": "onNotification", pushConfig: pushConfig});
 ```
 
 Start receiving messages:

--- a/example/index.html
+++ b/example/index.html
@@ -11,11 +11,12 @@
 <script type="text/javascript">
 
   function onDeviceReady() {
-    var aeroConfig = {
+    var pushConfig = {
       senderID: "<senderID>",
       pushServerURL: "<pushServerURL>",
       variantID: "<variantID>",
-      variantSecret: "<variantSecret>"
+      variantSecret: "<variantSecret>",
+      alias: "<alias>"
     }
 
     var statusList = $("#app-status-ul");
@@ -24,7 +25,7 @@
     try {
       statusList.append('<li>registering </li>');
       push.register(successHandler, errorHandler, {"badge": "true", "sound": "true",
-        "alert": "true", "ecb": "onNotification", aeroConfig: aeroConfig});
+        "alert": "true", "ecb": "onNotification", pushConfig: pushConfig});
     } catch (err) {
       txt = "There was an error on this page.\n\n";
       txt += "Error description: " + err.message + "\n\n";

--- a/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
+++ b/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
@@ -98,9 +98,9 @@ public class PushPlugin extends CordovaPlugin {
         javascriptCallback = (String) jo.get("ecb");
         Log.v(TAG, "execute: ECB=" + javascriptCallback);
 
-        JSONObject aeroConfig = jo.getJSONObject("aeroConfig");
+        JSONObject pushConfig = jo.getJSONObject("pushConfig");
 
-        saveConfig(aeroConfig);
+        saveConfig(pushConfig);
         cordova.getThreadPool().execute(new Runnable() {
           @Override
           public void run() {

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -82,7 +82,7 @@
     isInline = NO;
 
     [self.commandDelegate runInBackground:^{
-        [self saveConfig:[options objectForKey:@"aeroConfig"]];
+        [self saveConfig:[options objectForKey:@"pushConfig"]];
         [[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationTypes];
 
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
aeroConfig was used in aerodoc, I think pushConfig is a more generic name.
I also added the alias field,  which is needed,  in the sample configs.
