### PR TITLE
Removing Cocoa pods instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The available _platform_ values are _ios_ and _android_.
 
     cordova plugin add https://github.com/aerogear/aerogear-pushplugin-cordova.git
 
-Done! Now just open the project in your favorite mobile IDE, such as _Xcode_ or _Android Developer Tools_.
+Done! Your project now contains the AeroGear PushPlugin. For an integration with the _UnifiedPush Server_ open the ```www``` folder in your text editor and apply the code from the example below. Afterwards you can execute the project with ```cordova run <platform>```.
 
 ### Sample Example
 The below JavaScript code registers a device in the AeroGear Unified Push Server devices registry:


### PR DESCRIPTION
The `README` contains instructions for CocoaPods, however there is _no_ cocoapods dependency any more
