### PR TITLE
fix bug with android not sending cached message

### DIFF
--- a/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
+++ b/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
-import android.webkit.ValueCallback;
 import com.google.android.gcm.GCMRegistrar;
 import org.apache.cordova.*;
 import org.jboss.aerogear.android.Callback;
@@ -96,10 +95,9 @@ public class PushPlugin extends CordovaPlugin {
             register(callbackContext);
           }
         });
-
-        return true;
       } catch (JSONException e) {
         callbackContext.error(e.getMessage());
+        return false;
       }
 
       if (cachedMessage != null) {
@@ -108,6 +106,7 @@ public class PushPlugin extends CordovaPlugin {
         cachedMessage = null;
       }
 
+      return true;
     } else if (UNREGISTER.equals(action)) {
 
       unRegister(callbackContext);


### PR DESCRIPTION
Scenario: User taps the push notification when the app is not running.  The push notification is not being sent after the app is launched.  Also, removed unused import.
