### PR TITLE
Remove iOS SystemConfiguration.framework setting

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -64,6 +64,5 @@
     <source-file src="src/ios/libpush-sdk-0.9.0.a" framework="true"/>
     <framework src="Security.framework"/>
     <framework src="Foundation.framework"/>
-    <framework src="SystemConfiguration.framework"/>
   </platform>
 </plugin>


### PR DESCRIPTION
Remove iOS SystemConfiguration.framework setting from plugin.xml.  It
was setting this to false which conflicts with the network-information
plugin which sets this value to true.
