### PR TITLE
care for iOS 8 registration when running under that platform

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -86,7 +86,7 @@
         [self.commandDelegate evalJs:@"cordova.require('org.jboss.aerogear.cordova.push.AeroGear.UnifiedPush').successCallback()"];
     } failure:^(NSError *error) {
         NSString *errorMessage = [NSString stringWithFormat:@"Push registration Error: %@", error];
-        NSLog(errorMessage);
+        NSLog(@"%@", errorMessage);
         CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMessage];
         [self.commandDelegate sendPluginResult:commandResult callbackId:self.callbackId];
     }];


### PR DESCRIPTION
done for [AGCORDOVA-25](https://issues.jboss.org/browse/AGCORDOVA-25)

tested on both iOS 7 and iOS 8 device with push-helloworld demo and successfully registered and able to receive notifications.

Note:
you need to specify this branch when testing to get this version of the plugin that is:

`cordova plugin add https://github.com/cvasilak/aerogear-pushplugin-cordova.git#AGCORDOVA-25`
