### PR TITLE
removed whitespace so that Xcode recognises the remote notification flag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,9 +56,7 @@
     </config-file>
     <config-file target="*-Info.plist" parent="UIBackgroundModes">
       <array>
-        <string>
-          remote-notification
-        </string>
+        <string>remote-notification</string>
       </array>
     </config-file>
     <source-file src="src/ios/AppDelegate+notification.m"/>


### PR DESCRIPTION
How to test:
- create a cordova project
- add the plugin
- open xcode see the _Capabilities_ -> _Background Modes_

without this pr _Background Modes_ is on but _Remote Notifications_ is not, with this pr both are on
