### PR TITLE
fixed version of libpush-sdk to 1.0.0.a

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -70,7 +70,7 @@
     <header-file src="src/ios/AGDeviceRegistration.h"/>
     <header-file src="src/ios/AGClientDeviceInformation.h"/>
     <header-file src="src/ios/AeroGearPush.h"/>
-    <source-file src="src/ios/libpush-sdk-0.9.1.a" framework="true"/>
+    <source-file src="src/ios/libpush-sdk-1.0.0.a" framework="true"/>
   </platform>
   <platform name="firefoxos">
     <config-file target="config.xml" parent="/*">


### PR DESCRIPTION
this was accidentally changed by wrong rebase of https://github.com/aerogear/aerogear-pushplugin-cordova/commit/6bd8a51ab7500ee474b90d507a35fdc62efb626e
