### PR TITLE
Update dependency ID

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,7 +13,7 @@
     <engine name="cordova" version="&gt;=3.4.0"/>
     <engine name="cordova-android" version=">=4.0.0" />
   </engines>
-  <dependency id="com.vladstirbu.cordova.promise" url="https://github.com/vstirbu/PromisesPlugin.git"/>
+  <dependency id="es6-promise-plugin" url="https://github.com/vstirbu/PromisesPlugin.git"/>
   <js-module src="www/aerogear.ajax.js" name="AeroGear.ajax">
     <clobbers target="ajax" />
   </js-module>


### PR DESCRIPTION
PromisePlugin changed its plugin id. Thus, install via cordova CLI of aerogear fails. This commit fixes the dependency.