### PR TITLE
set promiseplugin dependency to before id change

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -12,7 +12,7 @@
   <engines>
     <engine name="cordova" version="&gt;=3.4.0"/>
   </engines>
-  <dependency id="com.vladstirbu.cordova.promise" url="https://github.com/vstirbu/PromisesPlugin.git"/>
+  <dependency id="com.vladstirbu.cordova.promise" url="https://github.com/vstirbu/PromisesPlugin.git#dafc1ff10607a3ccbae0e0e6d23445f8fa7929e9"/>
   <js-module src="www/aerogear.ajax.js" name="AeroGear.ajax">
     <clobbers target="ajax" />
   </js-module>


### PR DESCRIPTION
On the 7th July, the PromisesPlugin was changed to have a different id, and therefore cordova is complaining about the dependency id specified not matching the id of the plugin in the repository.
This pull request specifies a commit in the promiseplugin repo before the dependency id change
as discussed on the mailing list: http://aerogear-dev.1069024.n5.nabble.com/aerogear-dev-Push-plugin-for-Cordova-td11921.html