### PR TITLE
keep the message channel callback active

### DIFF
--- a/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
+++ b/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
@@ -164,8 +164,8 @@ public class PushPlugin extends CordovaPlugin {
           PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
           result.setKeepCallback(true);
           callbackContext.sendPluginResult(result);
-          
-          channel.success();
+
+          success();
         }
 
         @Override
@@ -176,6 +176,12 @@ public class PushPlugin extends CordovaPlugin {
     } catch (Exception e) {
       callbackContext.error(e.getMessage());
     }
+  }
+
+  private void success() {
+    PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
+    pluginResult.setKeepCallback(true);
+    channel.sendPluginResult(pluginResult);
   }
 
   private void unRegister(CallbackContext callbackContext) {


### PR DESCRIPTION
fix for issue [AGCORDOVA-125](https://issues.jboss.org/browse/AGCORDOVA-125)

How to test:
* remove the currently installed push plugin:
```cmd
$ cordova plugin rm aerogear-cordova-push
```
* install my branch:
```cmd
$ cordova plugin add https://github.com/edewit/aerogear-pushplugin-cordova#AGCORDOVA-125
```

Invoke the register method multiple times and see that the success callback is called for all of them.