### PR TITLE
add cold start detection for ios

### DIFF
--- a/src/ios/AGPushPlugin.m
+++ b/src/ios/AGPushPlugin.m
@@ -106,9 +106,13 @@
         NSMutableDictionary *extraPayload = [notificationMessage mutableCopy];
         NSDictionary *alert = message[@"alert"];
         
+        BOOL isColdStart =  [[[NSUserDefaults standardUserDefaults] objectForKey:@"AGPush_wasLaunchedWithOptions"] boolValue];
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"AGPush_wasLaunchedWithOptions"];
+        
         [extraPayload removeObjectForKey:@"aps"];
         message[@"payload"] = extraPayload;
         message[@"foreground"] = @(isInline);
+        message[@"coldstart"] = @(isColdStart);
         if ([alert isKindOfClass:[NSDictionary class]]) {
             message[@"alert"] = alert[@"body"];
             message[@"alert-extra"] = alert;

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -57,6 +57,7 @@ static char launchNotificationKey;
 
     if (notification) {
 		if (launchOptions) {
+            [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"AGPush_wasLaunchedWithOptions"];
             self.launchNotification = launchOptions[@"UIApplicationLaunchOptionsRemoteNotificationKey"];
         }
 	}
@@ -87,7 +88,6 @@ static char launchNotificationKey;
     }
 
     AGPushPlugin *pushHandler = [self getCommandInstance:@"PushPlugin"];
-
     if (appState == UIApplicationStateActive || appState == UIApplicationStateBackground) {
         pushHandler.notificationMessage = userInfo;
         pushHandler.isInline = YES;
@@ -119,7 +119,6 @@ static char launchNotificationKey;
 
     if (![self.viewController.webView isLoading] && self.launchNotification) {
         AGPushPlugin *pushHandler = [self getCommandInstance:@"PushPlugin"];
-
         pushHandler.notificationMessage = self.launchNotification;
         self.launchNotification = nil;
         [pushHandler performSelectorOnMainThread:@selector(notificationReceived) withObject:pushHandler waitUntilDone:NO];


### PR DESCRIPTION
How to test

Add the following code in the index.js
```javascript
 onNotification: function(event) {
        if ( event.coldstart )
            alert('coldstart');
}
```
Compile, deploy on an iOs device

1. Close the app, send a notification, click on the notification, alertbox is displayed
2. Put the app in background, send a notification, click on the notification, the alertbox is not displayed
3. Put the app in foreground, send a notification, the alertbox is not displayed.