### PR TITLE
added packaging exclude to fix build on cordova-cli 6.0

### DIFF
--- a/src/android/dependencies.gradle
+++ b/src/android/dependencies.gradle
@@ -11,3 +11,12 @@ dependencies {
 }
 
 cdvMinSdkVersion = 16
+
+android {
+    packagingOptions {
+        exclude 'META-INF/maven/com.madgag/scprov-jdk15on/pom.properties'
+        exclude 'META-INF/maven/com.madgag/scprov-jdk15on/pom.xml'
+        exclude 'META-INF/maven/com.madgag/sc-light-jdk15on/pom.properties'
+        exclude 'META-INF/maven/com.madgag/sc-light-jdk15on/pom.xml'
+    }
+ }


### PR DESCRIPTION
Fix for [AGCORDOVA-134](https://issues.jboss.org/browse/AGCORDOVA-134) 

@secondsun like this it builds again

How to test
=========
create new project with cordova cli 6.0.0:
```bash
$ cordova create plugin-test
$ cordova platform add android
```
install my branch:
```bash
$ cordova plugin add https://github.com/edewit/aerogear-pushplugin-cordova#cordova6
```
and verify that it builds:
```bash
$ cordova build
```