### PR TITLE
Adding AGDroid-3.0.x and perform API updates

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,13 +36,30 @@
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <activity android:name="org.jboss.aerogear.cordova.push.PushHandlerActivity"/>
-      <receiver android:name="org.jboss.aerogear.android.unifiedpush.gcm.AeroGearGCMMessageReceiver" android:permission="com.google.android.c2dm.permission.SEND">
+      <service android:name="org.jboss.aerogear.android.unifiedpush.gcm.UnifiedPushInstanceIDListenerService" android:exported="false">
         <intent-filter>
-          <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
-          <category android:name="$PACKAGE_NAME"/>
+          <action android:name="com.google.android.gms.iid.InstanceID"/>
         </intent-filter>
-        <meta-data android:name="DEFAULT_MESSAGE_HANDLER_KEY" android:value="org.jboss.aerogear.cordova.push.NotificationMessageHandler"/>
+      </service>
+      <receiver
+          android:name="com.google.android.gms.gcm.GcmReceiver"
+          android:exported="true"
+          android:permission="com.google.android.c2dm.permission.SEND" >
+          <intent-filter>
+              <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+              <category android:name="$PACKAGE_NAME"/>
+          </intent-filter>
       </receiver>
+      <service
+          android:name="org.jboss.aerogear.android.unifiedpush.gcm.AeroGearGCMMessageReceiver"
+          android:permission="com.google.android.c2dm.permission.SEND">
+          <intent-filter>
+              <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+          </intent-filter>
+          <meta-data
+              android:name="DEFAULT_MESSAGE_HANDLER_KEY"
+              android:value="org.jboss.aerogear.cordova.push.NotificationMessageHandler" />
+      </service>
     </config-file>
     <framework src="src/android/dependencies.gradle" type="gradleReference" custom="true"/>
     <source-file src="src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java" target-dir="src/org/jboss/aerogear/cordova/push/"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="aerogear-cordova-push" version="2.0.4">
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="aerogear-cordova-push" version="3.0.0">
   <name>
     AeroGear PushPlugin
   </name>

--- a/src/android/dependencies.gradle
+++ b/src/android/dependencies.gradle
@@ -4,10 +4,10 @@ repositories {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:22.+'
-    compile 'org.jboss.aerogear:aerogear-android-core:2.1.0'
-    compile 'org.jboss.aerogear:aerogear-android-pipe:2.1.0'
-    compile 'org.jboss.aerogear:aerogear-android-store:2.1.0'
-    compile 'org.jboss.aerogear:aerogear-android-push:2.2.2'
+    compile 'org.jboss.aerogear:aerogear-android-core:3.0.0'
+    compile 'org.jboss.aerogear:aerogear-android-pipe:3.0.0'
+    compile 'org.jboss.aerogear:aerogear-android-store:3.0.0'
+    compile 'org.jboss.aerogear:aerogear-android-push:3.0.1'
 }
 
 cdvMinSdkVersion = 16

--- a/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
+++ b/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
@@ -43,8 +43,7 @@ public class NotificationMessageHandler implements MessageHandler {
     if (store == null) {
       store = (SQLStore<Message>) DataManager.config("messageStore", SQLStoreConfiguration.class)
               .withContext(context)
-              .forClass(Message.class)
-              .store();
+              .store(Message.class);
       store.openSync();
     }
     Log.d(TAG, "onMessage - context: " + context);
@@ -58,16 +57,6 @@ public class NotificationMessageHandler implements MessageHandler {
         PushPlugin.sendMessage(message);
       }
     }
-  }
-
-  @Override
-  public void onDeleteMessage(Context context, Bundle message) {
-    Log.e(TAG, "onDeleteMessage: " + message);
-  }
-
-  @Override
-  public void onError() {
-    Log.e(TAG, "onError: ");
   }
 
   public void createNotification(Context context, Bundle extras) {

--- a/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
+++ b/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
@@ -197,11 +197,10 @@ public class PushPlugin extends CordovaPlugin {
     try {
       RegistrarManager.config(REGISTRAR, AeroGearGCMPushConfiguration.class)
               .setPushServerURI(new URI(preferences.getString(UNIFIED_PUSH_URL, null)))
-              .setSenderIds(preferences.getString(GCM_SENDER_ID, null))
+              .setSenderId(preferences.getString(GCM_SENDER_ID, null))
               .setVariantID(preferences.getString(VARIANT_ID, null))
               .setSecret(preferences.getString(SECRET, null))
               .setAlias(preferences.getString(ALIAS, null))
-              .setDeviceToken(preferences.getString(DEVICE_TOKEN, null))
               .setCategories(convert(preferences.getString(CATEGORIES, null)))
               .asRegistrar();
       return RegistrarManager.getRegistrar(REGISTRAR);


### PR DESCRIPTION
Done for [AGCORDOVA-138](https://issues.jboss.org/browse/AGCORDOVA-138)

@edewit Updating the plugin to use latest AeroGear-Android. Core/Pipe/Store are in 3.0.0, but push is already in 3.0.1 

The fix on 3.0.1-push (see https://github.com/aerogear/aerogear-android-push/pull/61) does make the plugin receive push messages 

