### PR TITLE
RHMAP-10715 Update aerogear-android-push to 4.0.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -45,6 +45,10 @@
         </intent-filter>
       </service>
     </config-file>
+    <framework src="com.google.firebase:firebase-messaging:9.4.0" />
+    <framework src="com.android.support:appcompat-v7:22.+" />
+    <framework src="org.jboss.aerogear:aerogear-android-store:3.0.2" />
+    <framework src="org.jboss.aerogear:aerogear-android-push:4.0.2" />
     <framework src="src/android/dependencies.gradle" type="gradleReference" custom="true"/>
     <source-file src="src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java" target-dir="src/org/jboss/aerogear/cordova/push/"/>
     <source-file src="src/android/org/jboss/aerogear/cordova/push/PushPlugin.java" target-dir="src/org/jboss/aerogear/cordova/push/"/>

--- a/src/android/dependencies.gradle
+++ b/src/android/dependencies.gradle
@@ -2,14 +2,6 @@ repositories {
     mavenLocal()
 }
 
-dependencies {
-    compile 'com.android.support:appcompat-v7:22.+'
-    compile 'org.jboss.aerogear:aerogear-android-core:3.0.0'
-    compile 'org.jboss.aerogear:aerogear-android-pipe:3.0.0'
-    compile 'org.jboss.aerogear:aerogear-android-store:3.0.2'
-    compile 'org.jboss.aerogear:aerogear-android-push:4.0.1'
-}
-
 cdvMinSdkVersion = 16
 cdvPluginPostBuildExtras << {
     apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
Updated aerogear-android-push to 4.0.2
Added `<framework src="com.google.firebase:firebase-messaging:9.4.0" />` to avoid problem where plugin: 'com.google.gms.google-services' installs firebase 9.0.
Moved dependencies to plugin.xml instead of dependencies.gradle
Removed 'org.jboss.aerogear:aerogear-android-core:3.0.0' and 'org.jboss.aerogear:aerogear-android-pipe:3.0.0' as they are dependencies of 'org.jboss.aerogear:aerogear-android-push:4.0.2'
