### PR TITLE
AGCORDOVA-158 (Android) Push not reflecting metrics when launching a …

### DIFF
--- a/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
+++ b/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
@@ -107,12 +107,6 @@ public class PushPlugin extends CordovaPlugin {
         return false;
       }
 
-      if (cachedMessage != null) {
-        Log.v(TAG, "sending cached extras");
-        sendMessage(cachedMessage);
-        cachedMessage = null;
-      }
-
       return true;
     } else if (UNREGISTER.equals(action)) {
 
@@ -176,6 +170,11 @@ public class PushPlugin extends CordovaPlugin {
     } catch (Exception e) {
       callbackContext.error(e.getMessage());
     }
+    if (cachedMessage != null) {
+      Log.v(TAG, "sending cached extras");
+      sendMessage(cachedMessage);
+      cachedMessage = null;
+    }
   }
 
   private void success() {
@@ -230,7 +229,7 @@ public class PushPlugin extends CordovaPlugin {
    */
   public static void sendMessage(Bundle message) {
     if (message != null) {
-      if (sendMetrics && !foreground) {
+      if (sendMetrics && (!foreground || cachedMessage != null)) {
         final UnifiedPushMetricsMessage metricsMessage = new UnifiedPushMetricsMessage(message);
         ((AeroGearFCMPushRegistrar)RegistrarManager.getRegistrar(REGISTRAR)).sendMetrics(metricsMessage, new Callback<UnifiedPushMetricsMessage>() {
           @Override


### PR DESCRIPTION
…stopped application

When the app is fully closed and you open it from the push message, at first the webview is not ready to execute code, so the message is cached. Once Cordova is ready and register is called, the app is in foreground, so the metric is not sent.

Changed to also check if cachedMessage is not null, that means that the app was launched from a push message while fully closed