### PR TITLE
Android: added notifications number on badge and reviewed notification click behaviour. 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,6 +49,7 @@
     <framework src="com.android.support:appcompat-v7:22.+" />
     <framework src="org.jboss.aerogear:aerogear-android-store:3.0.2" />
     <framework src="org.jboss.aerogear:aerogear-android-push:4.0.2" />
+    <framework src="me.leolin:ShortcutBadger:1.1.12@aar"/>
     <framework src="src/android/dependencies.gradle" type="gradleReference" custom="true"/>
     <source-file src="src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java" target-dir="src/org/jboss/aerogear/cordova/push/"/>
     <source-file src="src/android/org/jboss/aerogear/cordova/push/PushPlugin.java" target-dir="src/org/jboss/aerogear/cordova/push/"/>

--- a/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
+++ b/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
@@ -70,7 +70,8 @@ public class NotificationMessageHandler implements MessageHandler {
 
     Intent notificationIntent = new Intent(context, PushHandlerActivity.class);
     notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-    PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+    // Required Intent.FILL_IN_ACTION together with AndroidLaunchMode="singleTop" (instead of PendingIntent.FLAG_UPDATE_CURRENT).
+    PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, Intent.FILL_IN_ACTION);
 
     final String title = extras.getString("title");
     NotificationCompat.Builder builder =

--- a/src/android/org/jboss/aerogear/cordova/push/PushHandlerActivity.java
+++ b/src/android/org/jboss/aerogear/cordova/push/PushHandlerActivity.java
@@ -24,6 +24,8 @@ import android.util.Log;
 
 import org.jboss.aerogear.android.store.DataManager;
 import org.jboss.aerogear.android.store.Store;
+import org.jboss.aerogear.android.store.sql.SQLStore;
+import org.jboss.aerogear.android.store.sql.SQLStoreConfiguration;
 
 import java.util.Collection;
 
@@ -57,16 +59,30 @@ public class PushHandlerActivity extends Activity {
    */
   private void processPushBundle(boolean isPushPluginActive) {
     Store<Message> store = DataManager.getStore("messageStore");
-    Collection<Message> collection = store.readAll();
 
-    for (Message message : collection) {
-      Bundle originalExtras = message.toBundle();
-      if (!isPushPluginActive) {
-        originalExtras.putBoolean("coldstart", true);
-      }
+    // It may happen store is not initialize at this point.
+    if (store == null) {
+      store = (SQLStore<Message>) DataManager.config("messageStore", SQLStoreConfiguration.class)
+              .withContext(getApplicationContext())
+              .store(Message.class);
+      ((SQLStore<Message>)store).openSync();
     }
 
-    store.reset();
+    try {
+      Collection<Message> collection = store.readAll();
+      for (Message message : collection) {
+        Bundle originalExtras = message.toBundle();
+        if (!isPushPluginActive) {
+          originalExtras.putBoolean("coldstart", true);
+        }
+        // Send metrics for opened notification.
+        PushPlugin.sendMetricsForMessage(originalExtras);
+      }
+      store.reset();
+    }
+    catch(Exception e) {
+      Log.e(TAG, "processPushBundle: exception processing metrics for stored messages");
+    }
   }
 
   /**

--- a/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
+++ b/src/android/org/jboss/aerogear/cordova/push/PushPlugin.java
@@ -38,6 +38,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import me.leolin.shortcutbadger.ShortcutBadger;
+
 /**
  * @author edewit@redhat.com
  */
@@ -59,6 +61,9 @@ public class PushPlugin extends CordovaPlugin {
 
   private static final String REGISTRAR = "registrar";
   private static final String SETTINGS = "settings";
+
+  private static final String SET_APPLICATION_ICON_BADGE_NUMBER = "setApplicationIconBadgeNumber";
+  private static final String BADGE = "badge";
 
   private static CallbackContext context;
   private static CallbackContext channel;
@@ -118,6 +123,18 @@ public class PushPlugin extends CordovaPlugin {
       result.setKeepCallback(true);
       callbackContext.sendPluginResult(result);
       return true;
+    } else if (SET_APPLICATION_ICON_BADGE_NUMBER.equals(action)) {
+      cordova.getThreadPool().execute(new Runnable() {
+        public void run() {
+          Log.v(TAG, "setApplicationIconBadgeNumber: data=" + data.toString());
+          try {
+            setApplicationIconBadgeNumber(getApplicationContext(), data.getJSONObject(0).getInt(BADGE));
+          } catch (JSONException e) {
+            callbackContext.error(e.getMessage());
+          }
+          callbackContext.success();
+        }
+      });
     } else {
       callbackContext.error("Invalid action : " + action);
     }
@@ -362,6 +379,14 @@ public class PushPlugin extends CordovaPlugin {
     @Override
     public void onFailure(Exception e) {
       callbackContext.error(e.getMessage());
+    }
+  }
+
+  public static void setApplicationIconBadgeNumber(Context context, int badgeCount) {
+    if (badgeCount > 0) {
+      ShortcutBadger.applyCount(context, badgeCount);
+    } else {
+      ShortcutBadger.removeCount(context);
     }
   }
 }


### PR DESCRIPTION
There are three related changes

**1. Set notifications number on android app badge**
As in the iOS side, when the app is in background it is possible to set the badge number **using the same callback defined for iOS**.
- Number is displayed in both app icon and the badge shortcut if available.
- Of course behaviour depends on the device but I'm tested it in a set of devices with Android 4.4+ and it works.
- It uses me.leolin.shortcutbadger.ShortcutBadger.

**2. Launch app when user clicks on notification**
This feature was supposed to be available but unfortunately I never seen it working so I checked it and changed to fix.

**3. Update "opened" stats when user clicks on notification**
In Android, notifications " opened" stats (visible from aerogear admin page) were updated when the message was received. Now (as for iOS) "opened" stats are updated when the notification is opened by clicking on it (causing app relaunch).
