### PR TITLE
Prevent new push messages overwriting old message in Android app 

### DIFF
--- a/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
+++ b/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
@@ -97,6 +97,7 @@ public class NotificationMessageHandler implements MessageHandler {
       builder.setNumber(messageList.size());
     }
 
+    NOTIFICATION_ID = (int) System.currentTimeMillis();
     manager.notify(appName, NOTIFICATION_ID, builder.build());
   }
 


### PR DESCRIPTION
NOTIFICATION_ID will not be harcoded so we can keep all Android msgs ……just as in iOS. It was set to (int) System.currentTimeMillis() now. In iOS app, the same plugin keeps all push messages instead of overwriting old ones, this fix makes the behavior consistent between iOS and Android (to keep all push messages coming to the app)