### PR TITLE
Using custom notification icon in android

### DIFF
--- a/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
+++ b/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
@@ -77,7 +77,7 @@ public class NotificationMessageHandler implements MessageHandler {
     NotificationCompat.Builder builder =
         new NotificationCompat.Builder(context)
             .setDefaults(Notification.DEFAULT_ALL)
-            .setSmallIcon(context.getApplicationInfo().icon)
+            .setSmallIcon(context.getResources().getIdentifier("notification", "drawable", context.getPackageName()))
             .setWhen(System.currentTimeMillis())
             .setContentTitle(title != null ? title : appName)
             .setTicker(appName)


### PR DESCRIPTION
This change allows, on notification,  to show the custom (small white) notification icon instead of the default one. 

1. Icon has to be named notification.png

2. Icon must reside in res/android/ and must be declared in config.xml
```
<platform name="android"> 
   ... 
   <icon src="res/android/notification.png" /> 
   ...
</platform>
```

3. The icon file should be copied (automatically at build time or by hand) in 

`platforms/android/res/drawable`

