### PR TITLE
Update Android dependencies and add AndroidX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@
   cordova plugin add https://github.com/aerogear/aerogear-cordova-push.git#:/tests
   ```
 
-1. Add this plugin:
+3. Add this plugin:
   ```bash
   cordova plugin add http://git-wip-us.apache.org/repos/asf/cordova-plugin-test-framework.git
   ```
-1. Change the start page in `config.xml` with `<content src="cdvtests/index.html" />` or navigate to cdvtests/index.html from within your app.
+4. Change the start page in `config.xml` with `<content src="cdvtests/index.html" />` or navigate to cdvtests/index.html from within your app.
 
 ## Documentation
 
@@ -50,7 +50,22 @@ Many other plugins require Google Play Services and/or Firebase libraries. This 
 For example:
 
 ```
-cordova plugin add aerogear-cordova-push --variable FIREBASE_VERSION=11.8.0
+cordova plugin add aerogear-cordova-push --variable FIREBASE_VERSION=18.0.0
+```
+
+## AndroidX Support
+
+This plugin has [AndroidX](https://developer.android.com/jetpack/androidx) support. This means that you should migrate your project to AndroidX. To prevent to do it manually everytime, there are 2 great plugins to migrate it:
+
+1. First, enable AndroidX adding the [cordova-plugin-androidx](https://github.com/dpa99c/cordova-plugin-androidx) plugin:
+
+```
+cordova plugin add cordova-plugin-androidx
+```
+
+2. If you encounter build failures after installing (or after manually enabling AndroidX), try to install [cordova-plugin-androidx-adapter](https://github.com/dpa99c/cordova-plugin-androidx-adapter) into your project. It will migrate any references from the legacy Android Support library to use the new AndroidX which should resolve build failures.
+```
+cordova plugin add cordova-plugin-androidx-adapter
 ```
 
 ## Development

--- a/plugin.xml
+++ b/plugin.xml
@@ -31,29 +31,19 @@
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
       <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
+	  <uses-permission android:name="android.permission.INTERNET" />
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <activity android:name="org.jboss.aerogear.cordova.push.PushHandlerActivity"/>
       <meta-data android:name="DEFAULT_MESSAGE_HANDLER_KEY" android:value="org.jboss.aerogear.cordova.push.NotificationMessageHandler" />
-      <service android:name="org.jboss.aerogear.android.unifiedpush.fcm.UnifiedPushInstanceIDListenerService" android:exported="false">
-        <intent-filter>
-          <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
-        </intent-filter>
-      </service>
-      <service android:name="org.jboss.aerogear.android.unifiedpush.fcm.AeroGearFCMMessageReceiver">
-        <intent-filter>
-          <action android:name="com.google.firebase.MESSAGING_EVENT" />
-        </intent-filter>
-      </service>
     </config-file>
     <framework src="com.google.firebase:firebase-messaging:$FIREBASE_VERSION" />
-    <preference name="FIREBASE_VERSION" default="10.2.1"/>
-    <framework src="com.android.support:appcompat-v7:27.+" />
-    <framework src="com.android.support:support-v4:27.+" />
-    <framework src="com.android.support:support-compat:27.+" />
-    <framework src="com.android.support:support-annotations:27.+" />
+    <preference name="FIREBASE_VERSION" default="19.0.0"/>
+	<framework src="androidx.appcompat:appcompat:1.1.0" />
+	<framework src="androidx.core:core:1.1.0" />
+    <framework src="androidx.annotation:annotation:1.1.0" />
     <framework src="org.jboss.aerogear:aerogear-android-store:3.0.2" />
-    <framework src="org.jboss.aerogear:aerogear-android-push:4.0.2" />
+    <framework src="org.jboss.aerogear:aerogear-android-push:5.1.0" />
     <framework src="me.leolin:ShortcutBadger:1.1.12@aar"/>
     <framework src="src/android/dependencies.gradle" type="gradleReference" custom="true"/>
     <source-file src="src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java" target-dir="src/org/jboss/aerogear/cordova/push/"/>

--- a/scripts/androidBeforeInstall.js
+++ b/scripts/androidBeforeInstall.js
@@ -1,11 +1,7 @@
 module.exports = function(ctx) {
     var fs = require('fs'),
-        path = require('path'),
         os = require("os"),
         readline = require("readline");
-
-    var platformRoot = path.join(ctx.opts.projectRoot, 'www');
-    var settingsFile = path.join(platformRoot, 'google-services.json');
 
     var platformAndroid = 'platforms/android';
 
@@ -15,28 +11,18 @@ module.exports = function(ctx) {
     }
 
     return new Promise(function(resolve, reject) {
-        fs.stat(settingsFile, function(err,stats) {
-            if (err) {
-                reject("To use this plugin on android you'll need to add a google-services.json file with the FCM project_info and place that into your www folder");
-            } else {
-
-                fs.createReadStream(settingsFile).pipe(fs.createWriteStream(platformAndroid + '/google-services.json'));
-
-                var lineReader = readline.createInterface({
-                    terminal: false,
-                    input : fs.createReadStream(platformAndroid + '/build.gradle')
-                });
-                lineReader.on("line", function(line) {
-                    fs.appendFileSync('./build.gradle', line.toString() + os.EOL);
-                    if (/.*\ dependencies \{.*/.test(line)) {
-                        fs.appendFileSync('./build.gradle', '\t\tclasspath "com.google.gms:google-services:4.2.0"' + os.EOL);
-                        fs.appendFileSync('./build.gradle', '\t\tclasspath "com.android.tools.build:gradle:3.3.0"' + os.EOL);
-                    }
-                }).on("close", function () {
-                    fs.rename('./build.gradle', platformAndroid + '/build.gradle', resolve);
-                });
-
-            }
-        });
+		var lineReader = readline.createInterface({
+			terminal: false,
+			input : fs.createReadStream(platformAndroid + '/build.gradle')
+		});
+		lineReader.on("line", function(line) {
+			fs.appendFileSync('./build.gradle', line.toString() + os.EOL);
+			if (/.*\ dependencies \{.*/.test(line)) {
+				fs.appendFileSync('./build.gradle', '\t\tclasspath "com.google.gms:google-services:4.2.0"' + os.EOL);
+				fs.appendFileSync('./build.gradle', '\t\tclasspath "com.android.tools.build:gradle:3.3.0"' + os.EOL);
+			}
+		}).on("close", function () {
+			fs.rename('./build.gradle', platformAndroid + '/build.gradle', resolve);
+		});
     })
 };

--- a/scripts/androidBeforeInstall.js
+++ b/scripts/androidBeforeInstall.js
@@ -29,8 +29,8 @@ module.exports = function(ctx) {
                 lineReader.on("line", function(line) {
                     fs.appendFileSync('./build.gradle', line.toString() + os.EOL);
                     if (/.*\ dependencies \{.*/.test(line)) {
-                        fs.appendFileSync('./build.gradle', '\t\tclasspath "com.google.gms:google-services:3.0.0"' + os.EOL);
-                        fs.appendFileSync('./build.gradle', '\t\tclasspath "com.android.tools.build:gradle:1.2.3+"' + os.EOL);
+                        fs.appendFileSync('./build.gradle', '\t\tclasspath "com.google.gms:google-services:4.2.0"' + os.EOL);
+                        fs.appendFileSync('./build.gradle', '\t\tclasspath "com.android.tools.build:gradle:3.3.0"' + os.EOL);
                     }
                 }).on("close", function () {
                     fs.rename('./build.gradle', platformAndroid + '/build.gradle', resolve);

--- a/src/android/dependencies.gradle
+++ b/src/android/dependencies.gradle
@@ -2,7 +2,7 @@ repositories {
     mavenLocal()
 }
 
-cdvMinSdkVersion = Math.max(16, cdvHelpers.getConfigPreference('android-minSdkVersion', 0) as Integer)
+//cdvMinSdkVersion = Math.max(16, cdvHelpers.getConfigPreference('android-minSdkVersion', 0) as Integer)
 cdvPluginPostBuildExtras << {
     apply plugin: 'com.google.gms.google-services'
 }
@@ -17,15 +17,6 @@ if (file('src/main/AndroidManifest.xml').exists()) {
     manifestFile = 'AndroidManifest.xml'
 }
 
-import java.util.regex.Pattern
-
-def doExtractStringFromManifest(name) {
-    def manifestFile = file(android.sourceSets.main.manifest.srcFile)
-    def pattern = Pattern.compile(name + "=\"(.*?)\"")
-    def matcher = pattern.matcher(manifestFile.getText())
-    matcher.find()
-    return matcher.group(1)
-}
 
 android {
     sourceSets {
@@ -42,6 +33,6 @@ android {
     }
 
     defaultConfig {
-        applicationId = doExtractStringFromManifest("package")
+        applicationId cordovaConfig.PACKAGE_NAMESPACE
     }
  }

--- a/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
+++ b/src/android/org/jboss/aerogear/cordova/push/NotificationMessageHandler.java
@@ -25,8 +25,9 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.RequiresApi;
-import android.support.v4.app.NotificationCompat;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
 
 import org.jboss.aerogear.android.store.DataManager;
 import org.jboss.aerogear.android.store.sql.SQLStore;


### PR DESCRIPTION
## Motivation
Solves the issue discussed in [android-sdk repo](https://github.com/aerogear/aerogear-android-sdk/issues/295#issuecomment-570684168), to be able to use newer versions of firebase messaging.

## What
Updated the android dependencies versions, including [aeroger-cordova-push](https://github.com/aerogear/aerogear-android-push). Also, I needed to migrate the project to AndroidX. To make it easy, I updated the README with a new topic with instructions to migrate to AndroidX.

## Why
Without that, I could not use newer versions of firebase, like 19.0.0.

## Verification Steps

1. Remove the android platform
2. Remove the current plugin
3. Install the plugin from this fork with setting a new firebase version (e.g. --variable FIREBASE_VERSION=19.0.0)
4. Install the 2 plugins to migrate to AndroidX (as described in the README):
cordova plugin add cordova-plugin-androidx
cordova plugin add cordova-plugin-androidx-adapter
5. Add the latest android platform and run

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

PS.: I could not use it without to migrate to AndroidX. Maybe there is another way, but this is working for my purpose.